### PR TITLE
v0.1.3 fixes

### DIFF
--- a/lib/lti.ex
+++ b/lib/lti.ex
@@ -67,9 +67,9 @@ defmodule LTI do
 
   defp parse_url(url) do
     %URI{scheme: scheme, authority: authority, path: path, query: query} = URI.parse(url)
-    normalized_url = String.downcase("#{scheme}://#{authority}#{path}")
+    # normalized_url = String.downcase("#{scheme}://#{authority}#{path}")
 
-    {normalized_url, query}
+    {"#{scheme}://#{authority}#{path}", query}
   end
 
   defp to_query_params(nil), do: []

--- a/lib/lti.ex
+++ b/lib/lti.ex
@@ -41,7 +41,7 @@ defmodule LTI do
   end
 
   defp base_string(%Credentials{url: url}, oauth_params, launch_params) do
-    {normalized_url, query} = parse_url(url)
+    {normalized_url, query} = normalize(url)
     query_params = to_query_params(query)
 
     query =
@@ -65,11 +65,10 @@ defmodule LTI do
     end)
   end
 
-  defp parse_url(url) do
-    %URI{scheme: scheme, authority: authority, path: path, query: query} = URI.parse(url)
-    # normalized_url = String.downcase("#{scheme}://#{authority}#{path}")
+  defp normalize(url) do
+    %URI{query: query} = uri = URI.parse(url)
 
-    {"#{scheme}://#{authority}#{path}", query}
+    {URI.to_string(uri), query}
   end
 
   defp to_query_params(nil), do: []

--- a/lib/lti.ex
+++ b/lib/lti.ex
@@ -65,11 +65,18 @@ defmodule LTI do
     end)
   end
 
-  defp normalize(url) do
-    %URI{query: query} = uri = URI.parse(url)
+  def downcase_scheme_and_host(%URI{scheme: scheme, host: host} = uri),
+    do: %URI{uri | scheme: String.downcase(scheme), host: String.downcase(host)}
 
-    {URI.to_string(uri), query}
+  defp normalize(url) do
+    url
+    |> URI.parse()
+    |> downcase_scheme_and_host()
+    |> split_query_params()
   end
+
+  defp split_query_params(%URI{query: query} = uri),
+    do: {URI.to_string(%URI{uri | query: nil}), query}
 
   defp to_query_params(nil), do: []
 

--- a/lib/lti/launch_params.ex
+++ b/lib/lti/launch_params.ex
@@ -22,7 +22,6 @@ defmodule LTI.LaunchParams do
     :launch_presentation_locale,
     :launch_presentation_return_url,
     :lis_outcome_service_url,
-    :lis_result_sourcedid,
     :lis_person_contact_email_primary,
     :lis_person_name_family,
     :lis_person_name_full,

--- a/lib/lti_result.ex
+++ b/lib/lti_result.ex
@@ -129,7 +129,7 @@ defmodule LTIResult do
   end
 
   defp base_string(url, parameters) do
-    encoded_url = url |> String.downcase() |> percent_encode()
+    encoded_url = url |> percent_encode()
 
     query_string =
       parameters

--- a/lib/lti_result.ex
+++ b/lib/lti_result.ex
@@ -129,7 +129,12 @@ defmodule LTIResult do
   end
 
   defp base_string(url, parameters) do
-    encoded_url = url |> percent_encode()
+    encoded_url =
+      url
+      |> URI.parse()
+      |> LTI.downcase_scheme_and_host()
+      |> URI.to_string()
+      |> percent_encode()
 
     query_string =
       parameters


### PR DESCRIPTION
- [x] remove duplicate lis_result_sourceid from launchparams struct
~~do not downcase URLs that are being matched by LTI provider in the signature~~
- [x] downcase scheme and host of the resource URL per: https://tools.ietf.org/html/rfc5849#section-3.4.1.2