### PR TITLE
Support OTP24 by checking if new or old crypto API should be used

### DIFF
--- a/lib/lti.ex
+++ b/lib/lti.ex
@@ -29,7 +29,7 @@ defmodule LTI do
         %LaunchParams{} = launch_params
       ) do
     :sha
-    |> :crypto.hmac(
+    |> hmac_fun(
       encode_secret(secret),
       base_string(creds, oauth_params, launch_params)
     )
@@ -119,5 +119,11 @@ defmodule LTI do
     24
     |> :crypto.strong_rand_bytes()
     |> Base.encode64()
+  end
+
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    def hmac_fun(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    def hmac_fun(digest, key, data), do: :crypto.hmac(digest, key, data)
   end
 end

--- a/lib/lti_result.ex
+++ b/lib/lti_result.ex
@@ -45,7 +45,7 @@ defmodule LTIResult do
 
   defp generate_signature(secret, basestring) do
     :sha
-    |> :crypto.hmac(
+    |> LTI.hmac_fun(
       percent_encode(secret) <> "&",
       basestring
     )


### PR DESCRIPTION
The `:crypto.hmac/3` function is removed in `OTP >24`, but should still be used in `OTP <24`, this PR checks if the new Crypto API is available and uses that, otherwise it falls back to the older `:crypto.hmac` function.

I applied the solution from [plug_crypto](https://github.com/elixir-plug/plug_crypto/blob/6ba8fd42a68351459fe6c769ca04aea6022a5cd1/lib/plug/crypto/key_generator.ex#L96) for this.
